### PR TITLE
#59 Alles Material löschen Funktion hinzugefügt

### DIFF
--- a/src/components/abteilung/settings/AbteilungSettings.tsx
+++ b/src/components/abteilung/settings/AbteilungSettings.tsx
@@ -5,17 +5,13 @@ import { useNavigate } from 'react-router';
 import { Abteilung } from 'types/abteilung.type';
 import { useContext, useState } from 'react';
 import { firestore, functions } from 'config/firebase/firebase';
-import { abteilungenCollection } from 'config/firebase/collections';
+import { abteilungenCollection, abteilungenMaterialsCollection } from 'config/firebase/collections';
 import moduleStyles from '../Abteilung.module.scss'
 import { ability } from 'config/casl/ability';
 import { slugify } from 'util/FormUtil';
 import { Can } from 'config/casl/casl';
-import { DeleteOutlined, FileExcelOutlined } from '@ant-design/icons';
+import { DeleteOutlined } from '@ant-design/icons';
 import { validateMessages } from 'util/FormValdationMessages';
-import { excelToJson, exportMaterialsToXlsx } from 'util/ExcelUtil';
-import { ExcelImport } from './ExcelImport';
-import { ExcelJson } from 'types/excel.type';
-import {CategorysContext, MaterialsContext, StandorteContext} from '../AbteilungDetails';
 
 export interface AbteilungSettingsProps {
     abteilung: Abteilung
@@ -27,25 +23,8 @@ export const AbteilungSettings = (props: AbteilungSettingsProps) => {
 
     const navigate = useNavigate();
 
-    //fetch materials
-    const materialsContext = useContext(MaterialsContext);
-    const materials = materialsContext.materials;
-    const matLoading = materialsContext.loading;
-
-    //fetch categories
-    const categoriesContext = useContext(CategorysContext);
-    const categories = categoriesContext.categories;
-    const catLoading = categoriesContext.loading;
-
-    //fetch categories
-    const standorteContext = useContext(StandorteContext);
-    const standorte = standorteContext.standorte;
-    const standorteLoading = standorteContext.loading;
-
     const [form] = Form.useForm<Abteilung>();
     const [updateLoading, setUpdateLoading] = useState(false);
-    const [excelData, setExcelData] = useState<ExcelJson | undefined>();
-    const [showImportModal, setShowImportModal] = useState<boolean>(false);
 
     const [slug, setSlug] = useState<string>(abteilung.slug);
 
@@ -225,14 +204,10 @@ export const AbteilungSettings = (props: AbteilungSettingsProps) => {
                         </Form.Item>
                     </Col>
                     <Can I='update' this={abteilung}>
-                        <Col span={8}>
-                            <Form.Item wrapperCol={{ offset: 8, span: 16 }}>
-                                <Button type='primary' htmlType='submit' disabled={updateLoading}>
-                                    Speichern
-                                </Button>
-                            </Form.Item>
-                        </Col>
-                        <Col span={8}>
+                        <Col span={16}>
+                            <Button style={{ marginRight: '10px' }} type='primary' htmlType='submit' disabled={updateLoading}>
+                                Speichern
+                            </Button>
                             <Popconfirm
                                 title='Möchtest du diese Abteilung wirklich löschen?'
                                 onConfirm={() => delteAbteilung(abteilung)}
@@ -241,38 +216,13 @@ export const AbteilungSettings = (props: AbteilungSettingsProps) => {
                                 cancelText='Nein'
                             >
                                 <Button type='ghost' danger icon={<DeleteOutlined />} disabled={updateLoading}>
-                                    Löschen
+                                    Abteilung Löschen
                                 </Button>
                             </Popconfirm>
-                        </Col>
-                        <Col span={8}>
-                            <Button icon={<FileExcelOutlined />} onClick={()=> exportMaterialsToXlsx(abteilung, categories, materials, standorte)}>Excel export</Button>
-                        </Col>
-                        <Col span={8}>
-                            <Form.Item
-                                label='Material hochladen'
-                                name='upload'
-                            >
-                                <Input
-                                    type='file'
-                                    name='excelFile'
-                                    id='uploadExcel'
-                                    onChange={async (e) => {
-                                        const res = await excelToJson(e);
-                                        if(res) {
-                                            setExcelData(res)
-                                            setShowImportModal(true)
-                                        } else {
-                                            message.error('Leider ist ein Fehler beim lesen der Datei aufgetreten 2');
-                                        }
-                                    }}
-                                />
-                            </Form.Item>
                         </Col>
                     </Can>
                 </Row>
             </Form>
-            <ExcelImport abteilung={abteilung} excelData={excelData} showModal={showImportModal} setShow={setShowImportModal}/>
         </div>
     </Row>
 }

--- a/src/components/material/DeleteMaterial.tsx
+++ b/src/components/material/DeleteMaterial.tsx
@@ -1,0 +1,41 @@
+import { Button, Popconfirm, message } from 'antd';
+import {Abteilung} from 'types/abteilung.type';
+import { firestore } from 'config/firebase/firebase';
+import { abteilungenCollection, abteilungenMaterialsCollection} from "config/firebase/collections";
+import { DeleteOutlined } from '@ant-design/icons';
+import { useContext, useState } from 'react';
+
+export interface DeleteMaterialProps {
+    abteilung: Abteilung
+}
+
+export const DeleteMaterialButton = (props: DeleteMaterialProps) => {
+    const { abteilung} = props;
+    const [updateLoading] = useState(false);
+
+    const delteMaterial = async () => {
+        await firestore().collection(abteilungenCollection).doc(abteilung.id).collection(abteilungenMaterialsCollection).get().then((snapshot) => {
+            snapshot.docs.forEach((doc) => {
+                doc.ref.delete();
+            });
+        }).then(() => {
+            message.info(`Alles Material von ${abteilung.name} wurde erfolgreich gelöscht`);
+        }).catch((ex) => {
+            message.error(`Es ist ein Fehler aufgetreten: ${ex}`);
+        });
+    }
+
+    return <>
+        <Popconfirm
+            title='Möchtest du wirklich alles Material dieser Abteilung löschen?'
+            onConfirm={() => delteMaterial()}
+            onCancel={() => { }}
+            okText='Ja'
+            cancelText='Nein'
+        >
+        <Button type='ghost' danger icon={<DeleteOutlined />} disabled={updateLoading}>
+            Material Löschen
+        </Button>     
+        </Popconfirm>
+    </>
+}

--- a/src/components/material/ExcelImport.tsx
+++ b/src/components/material/ExcelImport.tsx
@@ -1,5 +1,19 @@
-import { Button, Col, message, Modal, Row, Select, Spin, Popconfirm } from "antd";
-import { abteilungenCategoryCollection, abteilungenMaterialsCollection, abteilungenCollection } from "config/firebase/collections";
+import {
+  Button,
+  Col,
+  message,
+  Modal,
+  Row,
+  Select,
+  Spin,
+  Popconfirm,
+  Tooltip,
+} from "antd";
+import {
+  abteilungenCategoryCollection,
+  abteilungenMaterialsCollection,
+  abteilungenCollection,
+} from "config/firebase/collections";
 import { firestore } from "config/firebase/firebase";
 import { useContext, useState } from "react";
 import { Abteilung } from "types/abteilung.type";
@@ -7,388 +21,483 @@ import { Categorie } from "types/categorie.types";
 import { ExcelJson } from "types/excel.type";
 import { Material } from "types/material.types";
 import { massImportMaterial } from "util/MaterialUtil";
-import {CategorysContext, StandorteContext} from "components/abteilung/AbteilungDetails";
+import {
+  CategorysContext,
+  StandorteContext,
+} from "components/abteilung/AbteilungDetails";
 
 export interface ExcelImportProps {
-    abteilung: Abteilung
-    excelData: ExcelJson | undefined
-    showModal: boolean
-    setShow: (show: boolean) => void
+  abteilung: Abteilung;
+  excelData: ExcelJson | undefined;
+  showModal: boolean;
+  setShow: (show: boolean) => void;
 }
 
 export const ExcelImport = (props: ExcelImportProps) => {
-    const { abteilung, excelData, showModal, setShow } = props;
+  const { abteilung, excelData, showModal, setShow } = props;
 
-    //fetch categories
-    const categoriesContext = useContext(CategorysContext);
-    const standorteContext = useContext(StandorteContext);
+  //fetch categories
+  const categoriesContext = useContext(CategorysContext);
+  const standorteContext = useContext(StandorteContext);
 
-    const categories = categoriesContext.categories;
-    const standorte = standorteContext.standorte;
-    const catLoading = categoriesContext.loading;
+  const categories = categoriesContext.categories;
+  const standorte = standorteContext.standorte;
+  const catLoading = categoriesContext.loading;
 
-    const [name, setName] = useState<string | undefined>();
-    const [comment, setComment] = useState<string | undefined>();
-    const [count, setCount] = useState<string | undefined>();
-    const [lost, setLost] = useState<string | undefined>();
-    const [damaged, setDamaged] = useState<string | undefined>();
-    const [location, setLocation] = useState<string | undefined>();
-    const [weightInKg, setWeightInKg] = useState<string | undefined>();
-    const [consumables, setConsumables] = useState<string | undefined>();
-    const [categorieIds, setCategorieIds] = useState<string | undefined>();
-    const [standort, setStandort] = useState<string | undefined>();
-    const [imageUrls, setImageUrls] = useState<string | undefined>();
-    const [onlyLendInternal, setOnlyLendInternal] = useState<string | undefined>();
+  const [name, setName] = useState<string | undefined>();
+  const [comment, setComment] = useState<string | undefined>();
+  const [count, setCount] = useState<string | undefined>();
+  const [lost, setLost] = useState<string | undefined>();
+  const [damaged, setDamaged] = useState<string | undefined>();
+  const [location, setLocation] = useState<string | undefined>();
+  const [weightInKg, setWeightInKg] = useState<string | undefined>();
+  const [consumables, setConsumables] = useState<string | undefined>();
+  const [categorieIds, setCategorieIds] = useState<string | undefined>();
+  const [standort, setStandort] = useState<string | undefined>();
+  const [imageUrls, setImageUrls] = useState<string | undefined>();
+  const [onlyLendInternal, setOnlyLendInternal] = useState<
+    string | undefined
+  >();
 
+  const findExampleData = (key: string | undefined): string => {
+    if (!excelData || !key) return "";
 
-    const findExampleData = (key: string | undefined): string => {
-        if (!excelData || !key) return '';
+    const index = excelData.headers.findIndex((h) => h === key);
 
-        const index = excelData.headers.findIndex(h => h === key);
-
-        const res = excelData.data.find(data => data[index] !== null);
-        if (res) {
-            return res[index] as string;
-        }
-
-        return '';
+    const res = excelData.data.find((data) => data[index] !== null);
+    if (res) {
+      return res[index] as string;
     }
 
-    const replaceMaterial = async () => {
-        await firestore().collection(abteilungenCollection).doc(abteilung.id).collection(abteilungenMaterialsCollection).get().then((snapshot) => {
-            snapshot.docs.forEach((doc) => {
-                doc.ref.delete();
-            });
-            prepareMaterial()
-        }).catch((ex) => {
-            message.error(`Es ist ein Fehler aufgetreten: ${ex}`);
+    return "";
+  };
+
+  const replaceMaterial = async () => {
+    await firestore()
+      .collection(abteilungenCollection)
+      .doc(abteilung.id)
+      .collection(abteilungenMaterialsCollection)
+      .get()
+      .then((snapshot) => {
+        snapshot.docs.forEach((doc) => {
+          doc.ref.delete();
         });
+        prepareMaterial();
+      })
+      .catch((ex) => {
+        message.error(`Es ist ein Fehler aufgetreten: ${ex}`);
+      });
+  };
+
+  const prepareMaterial = async (): Promise<Material[]> => {
+    const material: Material[] = [];
+
+    if (!excelData) return [];
+
+    if (!name) {
+      message.error("Du musst den Namen des Materials zuordnen.");
+      console.error("Du musst den Namen des Materials zuordnen.");
+      return [];
     }
 
-    const prepareMaterial = async (): Promise<Material[]> => {
-        const material: Material[] = [];
+    const indexes: { [key: string]: number } = {};
+    excelData.headers.forEach((key) => {
+      indexes[key] = excelData.headers.findIndex((h) => h === key);
+    });
 
-        if (!excelData) return [];
+    const newCategories: string[] = [];
+    const newStandorte: string[] = [];
 
-        if (!name) {
-            message.error('Du musst den Namen des Materials zuordnen.')
-            console.error('Du musst den Namen des Materials zuordnen.')
-            return [];
+    for (const dataArray of excelData.data) {
+      const matName: string = dataArray[indexes[name]] as string;
+      //skip if name is still not found
+      if (!matName) continue;
+      const matComment: string | null = comment
+        ? (dataArray[indexes[comment]] as string)
+        : null;
+      const matCount: number = count
+        ? (dataArray[indexes[count]] as number)
+        : 1;
+      const matLost: number = lost ? (dataArray[indexes[lost]] as number) : 0;
+      const matDamaged: number = damaged
+        ? (dataArray[indexes[damaged]] as number)
+        : 0;
+      const matWeightInKg: number | null = weightInKg
+        ? (dataArray[indexes[weightInKg]] as number)
+        : null;
+      const matConsumablest: boolean = consumables
+        ? (dataArray[indexes[consumables]] as boolean)
+        : false;
+      const matCategorienRaw: string | null = categorieIds
+        ? (dataArray[indexes[categorieIds]] as string)
+        : null;
+      const matStandorteRaw: string | null = standort
+        ? (dataArray[indexes[standort]] as string)
+        : null;
+      const matImageUrlsRaw: string | null = imageUrls
+        ? (dataArray[indexes[imageUrls]] as string)
+        : null;
+      const matonlyLendInternal: boolean = onlyLendInternal
+        ? (dataArray[indexes[onlyLendInternal]] as boolean)
+        : false;
+
+      let matCategorieNames: string[] = [];
+      let matImageUrls: string[] = [];
+      const materialCategorieIds: string[] = [];
+      let matStandortNames: string[] = [];
+      const matStandortIds: string[] = [];
+
+      //string to array of image urls
+      if (matImageUrlsRaw !== null) {
+        matImageUrls = matImageUrlsRaw.replaceAll(" ", "").split(",");
+      }
+
+      if (matCategorienRaw) {
+        matCategorieNames = matCategorienRaw.replaceAll(" ", "").split(",");
+      }
+
+      if (matStandorteRaw) {
+        matStandortNames = matStandorteRaw.replaceAll(" ", "").split(",");
+      }
+
+      //if cat is set loop through and assign category id
+      for (const catName of matCategorieNames) {
+        const placeholderName = "" + catName;
+        //check if cat already exists
+        const existingCat = categories.find(
+          (cat) => cat.name.toLowerCase() === catName.toLowerCase()
+        );
+        if (existingCat) {
+          materialCategorieIds.push(existingCat.id);
+          continue;
+        }
+        //check if cat is getting generated
+        const newCat = newCategories.find(
+          (cat) => cat.toLowerCase() === catName.toLowerCase()
+        );
+        if (newCat) {
+          materialCategorieIds.push(placeholderName);
+          continue;
         }
 
-        const indexes: { [key: string]: number } = {};
-        excelData.headers.forEach(key => {
-            indexes[key] = excelData.headers.findIndex(h => h === key)
-        })
+        //generate new cat
+        newCategories.push(catName);
 
-        const newCategories: string[] = [];
-        const newStandorte: string[] = [];
+        materialCategorieIds.push(placeholderName);
+      }
 
-        for( const dataArray of excelData.data) {
-            const matName: string = dataArray[indexes[name]] as string;
-            //skip if name is still not found
-            if (!matName) continue;
-            const matComment: string | null = comment ? dataArray[indexes[comment]] as string : null;
-            const matCount: number = count ? dataArray[indexes[count]] as number : 1;
-            const matLost: number = lost ? dataArray[indexes[lost]] as number : 0;
-            const matDamaged: number = damaged ? dataArray[indexes[damaged]] as number : 0;
-            const matWeightInKg: number | null = weightInKg ? dataArray[indexes[weightInKg]] as number : null;
-            const matConsumablest: boolean = consumables ? dataArray[indexes[consumables]] as boolean : false;
-            const matCategorienRaw: string | null = categorieIds ? dataArray[indexes[categorieIds]] as string : null;
-            const matStandorteRaw: string | null = standort ? dataArray[indexes[standort]] as string : null;
-            const matImageUrlsRaw: string | null = imageUrls ? dataArray[indexes[imageUrls]] as string : null;
-            const matonlyLendInternal: boolean = onlyLendInternal ? dataArray[indexes[onlyLendInternal]] as boolean : false;
-
-            let matCategorieNames: string[] = [];
-            let matImageUrls: string[] = [];
-            const materialCategorieIds: string[] = [];
-            let matStandortNames: string[] = [];
-            const matStandortIds: string[] = [];
-
-            //string to array of image urls
-            if (matImageUrlsRaw !== null) {
-                matImageUrls = matImageUrlsRaw.replaceAll(' ', '').split(',');
-            }
-
-            if (matCategorienRaw) {
-                matCategorieNames = matCategorienRaw.replaceAll(' ', '').split(',');
-            }
-
-            if (matStandorteRaw) {
-                matStandortNames = matStandorteRaw.replaceAll(' ', '').split(',');
-            }
-
-
-            //if cat is set loop through and assign category id
-            for(const catName of matCategorieNames) {
-                const placeholderName = '' + catName;
-                //check if cat already exists
-                const existingCat = categories.find(cat => cat.name.toLowerCase() === catName.toLowerCase());
-                if (existingCat) {
-                    materialCategorieIds.push(existingCat.id)
-                    continue;
-                }
-                //check if cat is getting generated
-                const newCat = newCategories.find(cat => cat.toLowerCase() === catName.toLowerCase());
-                if (newCat) {
-                    materialCategorieIds.push(placeholderName);
-                    continue;
-                }
-
-                //generate new cat
-                newCategories.push(catName)
-
-                materialCategorieIds.push(placeholderName);
-            }
-
-            //if ort is set loop through and assign ort id
-            for(const ortName of matStandortNames) {
-                const placeholderName = '' + ortName;
-                //check if ort already exists
-                const existingOrt = standorte.find(ort => ort.name.toLowerCase() === ortName.toLowerCase());
-                if (existingOrt) {
-                    matStandortIds.push(existingOrt.id)
-                    continue;
-                }
-                //check if ort is getting generated
-                const newOrt = newStandorte.find(ort => ort.toLowerCase() === ortName.toLowerCase());
-                if (newOrt) {
-                    matStandortIds.push(placeholderName);
-                    continue;
-                }
-
-                //generate new cat
-                newStandorte.push(ortName)
-
-                matStandortIds.push(placeholderName);
-            }
-
-
-            const matToAdd = {
-                name: matName,
-                comment: matComment,
-                count: matCount,
-                lost: matLost,
-                damaged: matDamaged,
-                weightInKg: matWeightInKg,
-                consumables: matConsumablest,
-                categorieIds: materialCategorieIds,
-                imageUrls: matImageUrls,
-                standort: matStandortIds,
-                onlyLendInternal: matonlyLendInternal
-            } as Material
-
-            material.push(matToAdd)
-
+      //if ort is set loop through and assign ort id
+      for (const ortName of matStandortNames) {
+        const placeholderName = "" + ortName;
+        //check if ort already exists
+        const existingOrt = standorte.find(
+          (ort) => ort.name.toLowerCase() === ortName.toLowerCase()
+        );
+        if (existingOrt) {
+          matStandortIds.push(existingOrt.id);
+          continue;
+        }
+        //check if ort is getting generated
+        const newOrt = newStandorte.find(
+          (ort) => ort.toLowerCase() === ortName.toLowerCase()
+        );
+        if (newOrt) {
+          matStandortIds.push(placeholderName);
+          continue;
         }
 
-        //create categories
-        const promieses = newCategories.map(catName => {
-            return firestore().collection(abteilungenCollection).doc(abteilung.id).collection(abteilungenCategoryCollection).add({ name: catName } as Categorie).then(doc => {
-                return {
-                    id: doc.id,
-                    name: catName
-                } as Categorie
-            })
-        })
+        //generate new cat
+        newStandorte.push(ortName);
 
-        const allCategories = await Promise.all(promieses);
+        matStandortIds.push(placeholderName);
+      }
 
-        //assign new catId to matCategorieIds
-        const materials = material.map(mat => {
-            const catIdsToSet: string[] = [];
-            if (mat.categorieIds && mat.categorieIds.length > 0) {
-                    mat.categorieIds.forEach(catPlaceholder => {
-                        const foundCat = allCategories.find(cat => cat.name === catPlaceholder)
-                        if (foundCat) {
-                            catIdsToSet.push(foundCat.id)
-                        } else {
-                            catIdsToSet.push(catPlaceholder)
-                        }
-                    })
-                mat.categorieIds = catIdsToSet;
-                return mat;
-            } else {
-                return mat;
-            }
-        })
+      const matToAdd = {
+        name: matName,
+        comment: matComment,
+        count: matCount,
+        lost: matLost,
+        damaged: matDamaged,
+        weightInKg: matWeightInKg,
+        consumables: matConsumablest,
+        categorieIds: materialCategorieIds,
+        imageUrls: matImageUrls,
+        standort: matStandortIds,
+        onlyLendInternal: matonlyLendInternal,
+      } as Material;
 
-        try {
-            await massImportMaterial(abteilung.id, materials)
-            message.success(`Es wurden erfolgreich ${material.length}/${excelData.data.length} Materialien importiert.`)
-            setShow(false)
-        } catch(err) {
-            message.error(`Es ist ein Fehler aufgetreten ${err}`)
-            console.error('Es ist ein Fehler aufgetreten', err)
-        }
-        
-
-        return materials;
+      material.push(matToAdd);
     }
 
-    if (!excelData) {
-        return <></>
+    //create categories
+    const promieses = newCategories.map((catName) => {
+      return firestore()
+        .collection(abteilungenCollection)
+        .doc(abteilung.id)
+        .collection(abteilungenCategoryCollection)
+        .add({ name: catName } as Categorie)
+        .then((doc) => {
+          return {
+            id: doc.id,
+            name: catName,
+          } as Categorie;
+        });
+    });
+
+    const allCategories = await Promise.all(promieses);
+
+    //assign new catId to matCategorieIds
+    const materials = material.map((mat) => {
+      const catIdsToSet: string[] = [];
+      if (mat.categorieIds && mat.categorieIds.length > 0) {
+        mat.categorieIds.forEach((catPlaceholder) => {
+          const foundCat = allCategories.find(
+            (cat) => cat.name === catPlaceholder
+          );
+          if (foundCat) {
+            catIdsToSet.push(foundCat.id);
+          } else {
+            catIdsToSet.push(catPlaceholder);
+          }
+        });
+        mat.categorieIds = catIdsToSet;
+        return mat;
+      } else {
+        return mat;
+      }
+    });
+
+    try {
+      await massImportMaterial(abteilung.id, materials);
+      message.success(
+        `Es wurden erfolgreich ${material.length}/${excelData.data.length} Materialien importiert.`
+      );
+      setShow(false);
+    } catch (err) {
+      message.error(`Es ist ein Fehler aufgetreten ${err}`);
+      console.error("Es ist ein Fehler aufgetreten", err);
     }
 
-    return <Modal
-        title='Material importieren'
-        visible={showModal}
-        onCancel={()=>  setShow(false)}
-        footer={[
-            <Button key='back' onClick={() => { setShow(false) }}>
-                Abbrechen
-            </Button>,
-            <Button key='importAdd' type='primary' disabled={!name || catLoading} onClick={() => { prepareMaterial() }}>
-                Importieren hinzufügen
-            </Button>,
-            <Popconfirm
-            title='Möchtest du wirklich alles bestehendes Material dieser Abteilung löschen?'
-            onConfirm={() => replaceMaterial()}
-            onCancel={() => { }}
-            okText='Ja'
-            cancelText='Nein'
+    return materials;
+  };
+
+  if (!excelData) {
+    return <></>;
+  }
+
+  return (
+    <Modal
+      title="Material importieren"
+      visible={showModal}
+      onCancel={() => setShow(false)}
+      footer={[
+        <Button
+          key="back"
+          onClick={() => {
+            setShow(false);
+          }}
+        >
+          Abbrechen
+        </Button>,
+        <Tooltip title="Bestehendes Material wird mit dem Inhalt der Excel-Tabelle ergänzt.">
+          <Button
+            key="importAdd"
+            type="primary"
+            disabled={!name || catLoading}
+            onClick={() => {
+              prepareMaterial();
+            }}
+          >
+            Importieren hinzufügen
+          </Button>
+        </Tooltip>,
+        <Popconfirm
+          title="Möchtest du wirklich alles bestehendes Material dieser Abteilung löschen?"
+          onConfirm={() => replaceMaterial()}
+          onCancel={() => {}}
+          okText="Ja"
+          cancelText="Nein"
+        >
+          <Tooltip title="Bestehendes Material wird gelöscht und mit dem Inhalt der Excel-Tabelle ersetzt.">
+            <Button
+              key="importReplace"
+              type="primary"
+              disabled={!name || catLoading}
             >
-                <Button key='importReplace' type='primary' disabled={!name || catLoading}>
-                    Importieren ersetzen
-                </Button>   
-            </Popconfirm>  
-        ]}
+              Importieren ersetzen
+            </Button>
+          </Tooltip>
+        </Popconfirm>,
+      ]}
     >
-        <Row gutter={[16, 16]}>
-            <Col span={12}>
-                <p>Name*:</p>
-                {
-                    name && <p>{`Beispiel: ${findExampleData(name)}`}</p>
-                }
-            </Col>
-            <Col span={12}>
-                <ExcelImportSelect options={excelData.headers} selected={name} setSelected={setName} />
-            </Col>
-            <Col span={12}>
-                <p>Bemerkung:</p>
-                {
-                    comment && <p>{`Beispiel: ${findExampleData(comment)}`}</p>
-                }
-            </Col>
-            <Col span={12}>
-                <ExcelImportSelect options={excelData.headers} selected={comment} setSelected={setComment} />
-            </Col>
-            <Col span={12}>
-                <p>Standort:</p>
-                {
-                    standort && <p>{`Beispiel: ${findExampleData(standort)}`}</p>
-                }
-            </Col>
-            <Col span={12}>
-                <ExcelImportSelect options={excelData.headers} selected={standort} setSelected={setStandort} />
-            </Col>
-            <Col span={12}>
-                <p>Anzahl:</p>
-                {
-                    count && <p>{`Beispiel: ${findExampleData(count)}`}</p>
-                }
-            </Col>
-            <Col span={12}>
-                <ExcelImportSelect options={excelData.headers} selected={count} setSelected={setCount} />
-            </Col>
-            <Col span={12}>
-                <p>Verloren:</p>
-                {
-                    lost && <p>{`Beispiel: ${findExampleData(lost)}`}</p>
-                }
-            </Col>
-            <Col span={12}>
-                <ExcelImportSelect options={excelData.headers} selected={lost} setSelected={setLost} />
-            </Col>
-            <Col span={12}>
-                <p>Beschädigt:</p>
-                {
-                    damaged && <p>{`Beispiel: ${findExampleData(damaged)}`}</p>
-                }
-            </Col>
-            <Col span={12}>
-                <ExcelImportSelect options={excelData.headers} selected={damaged} setSelected={setDamaged} />
-            </Col>
-            <Col span={12}>
-                <p>Gewicht in Kg:</p>
-                {
-                    weightInKg && <p>{`Beispiel: ${findExampleData(weightInKg)}`}</p>
-                }
-            </Col>
-            <Col span={12}>
-                <ExcelImportSelect options={excelData.headers} selected={weightInKg} setSelected={setWeightInKg} />
-            </Col>
-            <Col span={12}>
-                <p>Ist Verbrauchsmaterial:</p>
-                {
-                    consumables && <p>{`Beispiel: ${findExampleData(consumables)}`}</p>
-                }
-            </Col>
-            <Col span={12}>
-                <ExcelImportSelect options={excelData.headers} selected={consumables} setSelected={setConsumables} />
-            </Col>
-            <Col span={12}>
-                <p>Katergorien:</p>
-                {
-                    categorieIds && <p>{`Beispiel: ${findExampleData(categorieIds)}`}</p>
-                }
-            </Col>
-            <Col span={12}>
-                <ExcelImportSelect options={excelData.headers} selected={categorieIds} setSelected={setCategorieIds} />
-            </Col>
-            <Col span={12}>
-                <p>Bilder:</p>
-                {
-                    imageUrls && <p>{`Beispiel: ${findExampleData(imageUrls)}`}</p>
-                }
-            </Col>
-            <Col span={12}>
-                <ExcelImportSelect options={excelData.headers} selected={imageUrls} setSelected={setImageUrls} />
-            </Col>
-            <Col span={12}>
-                <p>Nur Intern ausleihbar:</p>
-                {
-                    onlyLendInternal && <p>{`Beispiel: ${findExampleData(onlyLendInternal)}`}</p>
-                }
-            </Col>
-            <Col span={12}>
-                <ExcelImportSelect options={excelData.headers} selected={onlyLendInternal} setSelected={setOnlyLendInternal} />
-            </Col>
+      <Row gutter={[16, 16]}>
+        <Col span={12}>
+          <p>Name*:</p>
+          {name && <p>{`Beispiel: ${findExampleData(name)}`}</p>}
+        </Col>
+        <Col span={12}>
+          <ExcelImportSelect
+            options={excelData.headers}
+            selected={name}
+            setSelected={setName}
+          />
+        </Col>
+        <Col span={12}>
+          <p>Bemerkung:</p>
+          {comment && <p>{`Beispiel: ${findExampleData(comment)}`}</p>}
+        </Col>
+        <Col span={12}>
+          <ExcelImportSelect
+            options={excelData.headers}
+            selected={comment}
+            setSelected={setComment}
+          />
+        </Col>
+        <Col span={12}>
+          <p>Standort:</p>
+          {standort && <p>{`Beispiel: ${findExampleData(standort)}`}</p>}
+        </Col>
+        <Col span={12}>
+          <ExcelImportSelect
+            options={excelData.headers}
+            selected={standort}
+            setSelected={setStandort}
+          />
+        </Col>
+        <Col span={12}>
+          <p>Anzahl:</p>
+          {count && <p>{`Beispiel: ${findExampleData(count)}`}</p>}
+        </Col>
+        <Col span={12}>
+          <ExcelImportSelect
+            options={excelData.headers}
+            selected={count}
+            setSelected={setCount}
+          />
+        </Col>
+        <Col span={12}>
+          <p>Verloren:</p>
+          {lost && <p>{`Beispiel: ${findExampleData(lost)}`}</p>}
+        </Col>
+        <Col span={12}>
+          <ExcelImportSelect
+            options={excelData.headers}
+            selected={lost}
+            setSelected={setLost}
+          />
+        </Col>
+        <Col span={12}>
+          <p>Beschädigt:</p>
+          {damaged && <p>{`Beispiel: ${findExampleData(damaged)}`}</p>}
+        </Col>
+        <Col span={12}>
+          <ExcelImportSelect
+            options={excelData.headers}
+            selected={damaged}
+            setSelected={setDamaged}
+          />
+        </Col>
+        <Col span={12}>
+          <p>Gewicht in Kg:</p>
+          {weightInKg && <p>{`Beispiel: ${findExampleData(weightInKg)}`}</p>}
+        </Col>
+        <Col span={12}>
+          <ExcelImportSelect
+            options={excelData.headers}
+            selected={weightInKg}
+            setSelected={setWeightInKg}
+          />
+        </Col>
+        <Col span={12}>
+          <p>Ist Verbrauchsmaterial:</p>
+          {consumables && <p>{`Beispiel: ${findExampleData(consumables)}`}</p>}
+        </Col>
+        <Col span={12}>
+          <ExcelImportSelect
+            options={excelData.headers}
+            selected={consumables}
+            setSelected={setConsumables}
+          />
+        </Col>
+        <Col span={12}>
+          <p>Katergorien:</p>
+          {categorieIds && (
+            <p>{`Beispiel: ${findExampleData(categorieIds)}`}</p>
+          )}
+        </Col>
+        <Col span={12}>
+          <ExcelImportSelect
+            options={excelData.headers}
+            selected={categorieIds}
+            setSelected={setCategorieIds}
+          />
+        </Col>
+        <Col span={12}>
+          <p>Bilder:</p>
+          {imageUrls && <p>{`Beispiel: ${findExampleData(imageUrls)}`}</p>}
+        </Col>
+        <Col span={12}>
+          <ExcelImportSelect
+            options={excelData.headers}
+            selected={imageUrls}
+            setSelected={setImageUrls}
+          />
+        </Col>
+        <Col span={12}>
+          <p>Nur Intern ausleihbar:</p>
+          {onlyLendInternal && (
+            <p>{`Beispiel: ${findExampleData(onlyLendInternal)}`}</p>
+          )}
+        </Col>
+        <Col span={12}>
+          <ExcelImportSelect
+            options={excelData.headers}
+            selected={onlyLendInternal}
+            setSelected={setOnlyLendInternal}
+          />
+        </Col>
 
-            {
-                catLoading && <Spin />
-            }
-        </Row>
+        {catLoading && <Spin />}
+      </Row>
     </Modal>
-}
+  );
+};
 
 export interface ExcelImportSelectProps {
-    options: string[]
-    selected: string | undefined
-    setSelected: (option: string) => void
+  options: string[];
+  selected: string | undefined;
+  setSelected: (option: string) => void;
 }
 
 const ExcelImportSelect = (props: ExcelImportSelectProps) => {
+  const { options, selected, setSelected } = props;
 
-    const { options, selected, setSelected } = props;
+  const { Option } = Select;
 
-    const { Option } = Select;
-
-    return <Select
-        showSearch
-        value={selected}
-        placeholder='Passendes Feld'
-        optionFilterProp='children'
-        onChange={setSelected}
-        filterOption={(input, option) => {
-            if (!option) return false;
-            return (option.children as any).toLowerCase().indexOf(input.toLowerCase()) >= 0
-        }}
-        style={{ width: '100%' }}
+  return (
+    <Select
+      showSearch
+      value={selected}
+      placeholder="Passendes Feld"
+      optionFilterProp="children"
+      onChange={setSelected}
+      filterOption={(input, option) => {
+        if (!option) return false;
+        return (
+          (option.children as any).toLowerCase().indexOf(input.toLowerCase()) >=
+          0
+        );
+      }}
+      style={{ width: "100%" }}
     >
-        <Option key='none' value={undefined}>Nicht vorhanden</Option>
-        {
-            options.map(o => <Option key={o} value={o}>{o}</Option>)
-        }
+      <Option key="none" value={undefined}>
+        Nicht vorhanden
+      </Option>
+      {options.map((o) => (
+        <Option key={o} value={o}>
+          {o}
+        </Option>
+      ))}
     </Select>
-}
+  );
+};

--- a/src/components/material/ExportMaterial.tsx
+++ b/src/components/material/ExportMaterial.tsx
@@ -1,0 +1,35 @@
+import { Button} from 'antd';
+import {Abteilung} from 'types/abteilung.type';
+import { useContext } from 'react';
+import { exportMaterialsToXlsx } from 'util/ExcelUtil';
+import {CategorysContext, MaterialsContext, StandorteContext} from 'components/abteilung/AbteilungDetails';
+
+export interface ExportMaterialProps {
+    abteilung: Abteilung
+}
+
+export const ExportMaterialButton = (props: ExportMaterialProps) => {
+    const { abteilung} = props;
+
+        //fetch materials
+        const materialsContext = useContext(MaterialsContext);
+        const materials = materialsContext.materials;
+        const matLoading = materialsContext.loading;
+    
+        //fetch categories
+        const categoriesContext = useContext(CategorysContext);
+        const categories = categoriesContext.categories;
+        const catLoading = categoriesContext.loading;
+    
+        //fetch categories
+        const standorteContext = useContext(StandorteContext);
+        const standorte = standorteContext.standorte;
+        const standorteLoading = standorteContext.loading;
+
+    
+    return <>
+         <Button type='primary' onClick={()=> exportMaterialsToXlsx(abteilung, categories, materials, standorte)}>
+            Excel export
+        </Button>
+    </>
+}

--- a/src/components/material/ImportAddMaterial.tsx
+++ b/src/components/material/ImportAddMaterial.tsx
@@ -17,6 +17,12 @@ export const ImportAddMaterialButton = (props: importAddMaterialProps) => {
     const [updateLoading] = useState(false);
     let excelInput = React.useRef<HTMLInputElement>(null);
 
+    function clearFileInput() {
+        if (excelInput.current?.value) {
+            excelInput.current.value = '';
+        }
+    }
+
     return <>
        <input
         style={{ display: 'none' }} 
@@ -33,6 +39,7 @@ export const ImportAddMaterialButton = (props: importAddMaterialProps) => {
                     message.error('Leider ist ein Fehler beim lesen der Datei aufgetreten 2');
                 }
             }}
+            onClick={clearFileInput}
         />
         <Button type='primary' disabled={updateLoading} onClick={() => excelInput?.current?.click()}>
             Excel Import

--- a/src/components/material/ImportAddMaterial.tsx
+++ b/src/components/material/ImportAddMaterial.tsx
@@ -1,0 +1,42 @@
+import { message,Button } from 'antd';
+import {Abteilung} from 'types/abteilung.type';
+import { useState } from 'react';
+import { ExcelJson } from 'types/excel.type';
+import { ExcelImport } from './ExcelImport';
+import { excelToJson } from 'util/ExcelUtil';
+import React from 'react'
+
+export interface importAddMaterialProps {
+    abteilung: Abteilung
+}
+
+export const ImportAddMaterialButton = (props: importAddMaterialProps) => {
+    const { abteilung} = props;
+    const [excelData, setExcelData] = useState<ExcelJson | undefined>();
+    const [showImportModal, setShowImportModal] = useState<boolean>(false);
+    const [updateLoading] = useState(false);
+    let excelInput = React.useRef<HTMLInputElement>(null);
+
+    return <>
+       <input
+        style={{ display: 'none' }} 
+            type='file'
+            name='excelFile'
+            id='uploadExcel'
+            ref = {excelInput}
+            onChange={async (e) => {
+                const res = await excelToJson(e);
+                if(res) {
+                    setExcelData(res)
+                    setShowImportModal(true)
+                } else {
+                    message.error('Leider ist ein Fehler beim lesen der Datei aufgetreten 2');
+                }
+            }}
+        />
+        <Button type='primary' disabled={updateLoading} onClick={() => excelInput?.current?.click()}>
+            Excel Import
+        </Button>     
+        <ExcelImport abteilung={abteilung} excelData={excelData} showModal={showImportModal} setShow={setShowImportModal}/>
+    </>
+}

--- a/src/views/abteilung/material/abteilungMaterials.tsx
+++ b/src/views/abteilung/material/abteilungMaterials.tsx
@@ -16,6 +16,9 @@ import moment from 'moment';
 import {Material} from 'types/material.types';
 import {getAvailableMatCount} from 'util/MaterialUtil';
 import {AddStandortButton} from "components/standort/AddStandort";
+import {ImportAddMaterialButton} from 'components/material/ImportAddMaterial';
+import {DeleteMaterialButton} from 'components/material/DeleteMaterial';
+import {ExportMaterialButton} from 'components/material/ExportMaterial';
 
 export type AbteilungMaterialViewProps = {
     abteilung: Abteilung;
@@ -124,6 +127,18 @@ export const AbteilungMaterialView = (props: AbteilungMaterialViewProps) => {
                 <AddStandortButton abteilungId={abteilung.id} />
             </Can>
         </Col>
+        <Can I={'delete'} this={{ __caslSubjectType__: 'Material', abteilungId: abteilung.id } as AbteilungEntityCasl}>
+            <Col hidden={windowSize[0] < 769} xl={4}>
+                    <ImportAddMaterialButton abteilung={abteilung} />
+            </Col>
+            <Col hidden={windowSize[0] < 769} xl={4}>
+                <ExportMaterialButton abteilung={abteilung} />
+            </Col>
+            <Col hidden={windowSize[0] < 769} xl={4}>
+                <DeleteMaterialButton abteilung={abteilung} />
+            </Col>
+        </Can>
+        
 
         {
             matLoading || catLoading ?


### PR DESCRIPTION
Button um alles Material der Abteilung zu löschen auf der Material Seite der eigenen Abteilung hinzugefügt.

Änderung beim Importieren des Excels, muss nun ausgewählt werden ob das neue Material zum bestehenden Material der Abteilung hinzugefügt werden soll, oder ob das Bisherige Material ersetzt werden soll.

Buttons für den Excel Import und Export auf die Material Seite der eigenen Abteilung verschoben. Vorher unter Abteilung => Settings.

Kleine visuelle Verbesserungen.